### PR TITLE
4 use newer llm versions for party response generation

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,1 @@
+!.env.example

--- a/src/chatbot_async.py
+++ b/src/chatbot_async.py
@@ -17,8 +17,8 @@ from openai.types.chat.chat_completion_message_param import (
 
 from src.models.general import LLM, LLMSize
 from src.llms import (
-    DETERMINISTIC_LLMS,
-    NON_DETERMINISTIC_LLMS,
+    PRE_AND_POST_PROCESSING_LLMS,
+    RESPONSE_GENERATION_LLMS,
     get_answer_from_llms,
     get_structured_output_from_llms,
     stream_answer_from_llms,
@@ -78,21 +78,23 @@ load_env()
 logger = logging.getLogger(__name__)
 
 
-chat_response_llms: list[LLM] = NON_DETERMINISTIC_LLMS
+chat_response_llms: list[LLM] = RESPONSE_GENERATION_LLMS
 
-voting_behavior_summary_llms: list[LLM] = NON_DETERMINISTIC_LLMS
+voting_behavior_summary_llms: list[LLM] = RESPONSE_GENERATION_LLMS
 
-prompt_improvement_llms: list[LLM] = DETERMINISTIC_LLMS
+prompt_improvement_llms: list[LLM] = PRE_AND_POST_PROCESSING_LLMS
 
-generate_party_list_llms: list[LLM] = DETERMINISTIC_LLMS
+generate_party_list_llms: list[LLM] = PRE_AND_POST_PROCESSING_LLMS
 
-generate_message_type_and_general_question_llms: list[LLM] = DETERMINISTIC_LLMS
+generate_message_type_and_general_question_llms: list[LLM] = (
+    PRE_AND_POST_PROCESSING_LLMS
+)
 
-generate_chat_summary_llms: list[LLM] = DETERMINISTIC_LLMS
+generate_chat_summary_llms: list[LLM] = PRE_AND_POST_PROCESSING_LLMS
 
-generate_chat_title_and_quick_replies_llms: list[LLM] = DETERMINISTIC_LLMS
+generate_chat_title_and_quick_replies_llms: list[LLM] = PRE_AND_POST_PROCESSING_LLMS
 
-reranking_llms = DETERMINISTIC_LLMS
+reranking_llms = PRE_AND_POST_PROCESSING_LLMS
 
 perplexity_client = AsyncOpenAI(
     api_key=os.getenv("PERPLEXITY_API_KEY"), base_url="https://api.perplexity.ai"

--- a/src/llms.py
+++ b/src/llms.py
@@ -16,13 +16,6 @@ load_env()
 logger = logging.getLogger(__name__)
 
 
-CAPACITY_GEMINI_2_FLASH = 108
-CAPACITY_GPT_4O_OPENAI_TIER_5 = 3759
-CAPACITY_GPT_4O_AZURE = 112
-CAPACITY_GPT_4O_MINI_OPENAI_TIER_5 = 4054
-CAPACITY_GPT_4O_MINI_AZURE = 108
-
-
 azure_gpt_4o = AzureChatOpenAI(
     azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
     deployment_name="gpt-4o-2024-08-06",
@@ -63,7 +56,6 @@ NON_DETERMINISTIC_LLMS: list[LLM] = [
         model=google_gemini_2_flash,
         sizes=[LLMSize.SMALL, LLMSize.LARGE],
         priority=100,
-        user_capacity_per_minute=CAPACITY_GEMINI_2_FLASH,
         is_at_rate_limit=False,
     ),
     LLM(
@@ -71,7 +63,6 @@ NON_DETERMINISTIC_LLMS: list[LLM] = [
         model=azure_gpt_4o,
         sizes=[LLMSize.LARGE],
         priority=90,
-        user_capacity_per_minute=CAPACITY_GPT_4O_AZURE,
         is_at_rate_limit=False,
         premium_only=True,
     ),
@@ -80,7 +71,6 @@ NON_DETERMINISTIC_LLMS: list[LLM] = [
         model=openai_gpt_4o,
         sizes=[LLMSize.LARGE],
         priority=98,
-        user_capacity_per_minute=CAPACITY_GPT_4O_OPENAI_TIER_5,
         is_at_rate_limit=False,
         premium_only=False,
     ),
@@ -89,7 +79,6 @@ NON_DETERMINISTIC_LLMS: list[LLM] = [
         model=azure_gpt_4o_mini,
         sizes=[LLMSize.SMALL],
         priority=50,
-        user_capacity_per_minute=CAPACITY_GPT_4O_MINI_AZURE,
         is_at_rate_limit=False,
     ),
     LLM(
@@ -97,7 +86,6 @@ NON_DETERMINISTIC_LLMS: list[LLM] = [
         model=openai_gpt_4o_mini,
         sizes=[LLMSize.SMALL],
         priority=40,
-        user_capacity_per_minute=CAPACITY_GPT_4O_MINI_OPENAI_TIER_5,
         is_at_rate_limit=False,
     ),
 ]
@@ -132,7 +120,6 @@ DETERMINISTIC_LLMS: list[LLM] = [
         model=google_gemini_2_flash_det,
         sizes=[LLMSize.SMALL, LLMSize.LARGE],
         priority=100,
-        user_capacity_per_minute=CAPACITY_GEMINI_2_FLASH,
         is_at_rate_limit=False,
     ),
     LLM(
@@ -140,7 +127,6 @@ DETERMINISTIC_LLMS: list[LLM] = [
         model=azure_gpt_4o_mini_det,
         sizes=[LLMSize.SMALL],
         priority=90,
-        user_capacity_per_minute=CAPACITY_GPT_4O_MINI_AZURE,
         is_at_rate_limit=False,
     ),
     LLM(
@@ -148,7 +134,6 @@ DETERMINISTIC_LLMS: list[LLM] = [
         model=openai_gpt_4o_mini_det,
         sizes=[LLMSize.SMALL],
         priority=80,
-        user_capacity_per_minute=CAPACITY_GPT_4O_MINI_OPENAI_TIER_5,
         is_at_rate_limit=False,
     ),
 ]

--- a/src/llms.py
+++ b/src/llms.py
@@ -39,7 +39,7 @@ google_gemini_2_flash = ChatGoogleGenerativeAI(
 )
 
 google_gemini_3_flash_preview = ChatGoogleGenerativeAI(
-    model="gemini-3.0-flash-preview",
+    model="gemini-3-flash-preview",
     api_key=safe_load_api_key("GOOGLE_API_KEY"),
     max_retries=0,
 )

--- a/src/llms.py
+++ b/src/llms.py
@@ -63,7 +63,7 @@ openai_gpt_4o_mini = ChatOpenAI(
     max_retries=0,
 )
 
-NON_DETERMINISTIC_LLMS: list[LLM] = [
+RESPONSE_GENERATION_LLMS: list[LLM] = [
     LLM(
         name="google-gemini-3.0-flash-preview",
         model=google_gemini_3_flash_preview,
@@ -148,7 +148,7 @@ openai_gpt_4o_mini_det = ChatOpenAI(
     max_retries=0,
 )
 
-DETERMINISTIC_LLMS: list[LLM] = [
+PRE_AND_POST_PROCESSING_LLMS: list[LLM] = [
     LLM(
         name="google-gemini-2.5-flash-lite-preview-09-2025",
         model=google_gemini_2_5_flash_lite_preview_det,

--- a/src/llms.py
+++ b/src/llms.py
@@ -44,6 +44,12 @@ google_gemini_3_flash_preview = ChatGoogleGenerativeAI(
     max_retries=0,
 )
 
+google_gemini_2_5_flash_preview = ChatGoogleGenerativeAI(
+    model="gemini-2.5-flash-preview-09-2025",
+    api_key=safe_load_api_key("GOOGLE_API_KEY"),
+    max_retries=0,
+)
+
 openai_gpt_4o = ChatOpenAI(
     model="gpt-4o-2024-08-06",
     api_key=safe_load_api_key("OPENAI_API_KEY"),
@@ -65,10 +71,17 @@ NON_DETERMINISTIC_LLMS: list[LLM] = [
         is_at_rate_limit=False,
     ),
     LLM(
+        name="google-gemini-2.5-flash-preview-09-2025",
+        model=google_gemini_2_5_flash_preview,
+        sizes=[LLMSize.SMALL, LLMSize.LARGE],
+        priority=95,
+        is_at_rate_limit=False,
+    ),
+    LLM(
         name="google-gemini-2.0-flash",
         model=google_gemini_2_flash,
         sizes=[LLMSize.SMALL, LLMSize.LARGE],
-        priority=95,
+        priority=92,
         is_at_rate_limit=False,
     ),
     LLM(
@@ -112,6 +125,13 @@ azure_gpt_4o_mini_det = AzureChatOpenAI(
     max_retries=0,
 )
 
+google_gemini_2_5_flash_lite_preview = ChatGoogleGenerativeAI(
+    model="gemini-2.5-flash-lite-preview-09-2025",
+    api_key=safe_load_api_key("GOOGLE_API_KEY"),
+    temperature=0.0,
+    max_retries=0,
+)
+
 google_gemini_2_flash_det = ChatGoogleGenerativeAI(
     model="gemini-2.0-flash",
     api_key=safe_load_api_key("GOOGLE_API_KEY"),
@@ -129,10 +149,17 @@ openai_gpt_4o_mini_det = ChatOpenAI(
 
 DETERMINISTIC_LLMS: list[LLM] = [
     LLM(
+        name="google-gemini-2.5-flash-lite-preview-09-2025",
+        model=google_gemini_2_5_flash_lite_preview,
+        sizes=[LLMSize.SMALL],
+        priority=100,
+        is_at_rate_limit=False,
+    ),
+    LLM(
         name="google-gemini-2.0-flash-det",
         model=google_gemini_2_flash_det,
         sizes=[LLMSize.SMALL, LLMSize.LARGE],
-        priority=100,
+        priority=95,
         is_at_rate_limit=False,
     ),
     LLM(

--- a/src/llms.py
+++ b/src/llms.py
@@ -42,6 +42,7 @@ google_gemini_3_flash_preview = ChatGoogleGenerativeAI(
     model="gemini-3-flash-preview",
     api_key=safe_load_api_key("GOOGLE_API_KEY"),
     max_retries=0,
+    temperature=1.0,  # Explicitly set temperature to 1.0 based on Google's recommendation in https://ai.google.dev/gemini-api/docs/gemini-3#temperature
 )
 
 google_gemini_2_5_flash_preview = ChatGoogleGenerativeAI(

--- a/src/llms.py
+++ b/src/llms.py
@@ -38,6 +38,12 @@ google_gemini_2_flash = ChatGoogleGenerativeAI(
     max_retries=0,
 )
 
+google_gemini_3_flash_preview = ChatGoogleGenerativeAI(
+    model="gemini-3.0-flash-preview",
+    api_key=safe_load_api_key("GOOGLE_API_KEY"),
+    max_retries=0,
+)
+
 openai_gpt_4o = ChatOpenAI(
     model="gpt-4o-2024-08-06",
     api_key=safe_load_api_key("OPENAI_API_KEY"),
@@ -52,10 +58,17 @@ openai_gpt_4o_mini = ChatOpenAI(
 
 NON_DETERMINISTIC_LLMS: list[LLM] = [
     LLM(
+        name="google-gemini-3.0-flash-preview",
+        model=google_gemini_3_flash_preview,
+        sizes=[LLMSize.SMALL, LLMSize.LARGE],
+        priority=100,
+        is_at_rate_limit=False,
+    ),
+    LLM(
         name="google-gemini-2.0-flash",
         model=google_gemini_2_flash,
         sizes=[LLMSize.SMALL, LLMSize.LARGE],
-        priority=100,
+        priority=95,
         is_at_rate_limit=False,
     ),
     LLM(

--- a/src/llms.py
+++ b/src/llms.py
@@ -126,7 +126,7 @@ azure_gpt_4o_mini_det = AzureChatOpenAI(
     max_retries=0,
 )
 
-google_gemini_2_5_flash_lite_preview = ChatGoogleGenerativeAI(
+google_gemini_2_5_flash_lite_preview_det = ChatGoogleGenerativeAI(
     model="gemini-2.5-flash-lite-preview-09-2025",
     api_key=safe_load_api_key("GOOGLE_API_KEY"),
     temperature=0.0,
@@ -151,7 +151,7 @@ openai_gpt_4o_mini_det = ChatOpenAI(
 DETERMINISTIC_LLMS: list[LLM] = [
     LLM(
         name="google-gemini-2.5-flash-lite-preview-09-2025",
-        model=google_gemini_2_5_flash_lite_preview,
+        model=google_gemini_2_5_flash_lite_preview_det,
         sizes=[LLMSize.SMALL],
         priority=100,
         is_at_rate_limit=False,

--- a/src/models/general.py
+++ b/src/models/general.py
@@ -23,10 +23,6 @@ class LLM(BaseModel):
         ...,
         description="The priority for using this LLM above other options. The higher the number, the higher the priority.",
     )
-    user_capacity_per_minute: int = Field(
-        ...,
-        description="The number of concurrent active wahl.chat users that are estimated to be able use the model per minute.",
-    )
     is_at_rate_limit: bool = Field(
         ...,
         description="Boolean True, if the model is at rate limit, otherwise False.",


### PR DESCRIPTION
Note: we are only switching to newer Gemini models in the MR as adding support for gpt-5-mini and other gpt-5-series models requires upgrading to langchain 1.x or switching the LLM abstraction which will be done in a separate MR